### PR TITLE
Bug: Fixed wrong paranthesis while printing ternary operators in PrintITL

### DIFF
--- a/src/plugin/PrintITL/DatapathVisitor.cpp
+++ b/src/plugin/PrintITL/DatapathVisitor.cpp
@@ -156,5 +156,15 @@ void DESCAM::DatapathVisitor::visit(DESCAM::UnaryExpr &node) {
         this->ss << ")";
 }
 
+void DESCAM::DatapathVisitor::visit(DESCAM::Ternary & node) {
+    this->ss << "(";
+    node.getCondition()->accept(*this);
+    this->ss << "?";
+    node.getTrueExpr()->accept(*this);
+    this->ss << ":";
+    node.getFalseExpr()->accept(*this);
+    this->ss << ")";
+}
+
 
 

--- a/src/plugin/PrintITL/DatapathVisitor.h
+++ b/src/plugin/PrintITL/DatapathVisitor.h
@@ -56,6 +56,8 @@ namespace DESCAM {
 
         void visit(class UnaryExpr &node) override;
 
+        void visit(class Ternary &node) override;
+
         bool resize_flag = false;
         std::string tp = "_at_t";
     };


### PR DESCRIPTION
The ternary operator has been printed in a "(a)?b:c" fashion. 
However, ITL expects a bracket around the expression, otherwise "x = (a)?b:c" tries to compare x with a.
The new visitor prints it as "(a?b:c)".

ITL Test case for ternary has to be adjusted accordingly.

Also consider doing the change inside PrintStmt instead of DatapathVisitor.